### PR TITLE
Remove foreign key

### DIFF
--- a/db.go
+++ b/db.go
@@ -36,7 +36,4 @@ func dbInit() {
 	db.AutoMigrate(&Media{})
 	db.AutoMigrate(&List{})
 	db.AutoMigrate(&User{})
-
-	// Add / verify foreign keys
-	db.Exec("ALTER TABLE `list_media` ADD CONSTRAINT `fk_list_id` FOREIGN KEY (`list_id`) REFERENCES `list` (`id`) ON UPDATE CASCADE ON DELETE CASCADE, ADD CONSTRAINT `fk_media_id` FOREIGN KEY (`media_id`) REFERENCES `media` (`id`) ON UPDATE CASCADE ON DELETE CASCADE;")
 }

--- a/streamlist.go
+++ b/streamlist.go
@@ -153,16 +153,9 @@ func DeleteMedia(id string) error {
 		return nil
 	}
 
-	// Remove all list references to this media.
-	lists, err := listLists()
-	if err != nil {
-		return err
-	}
-	for _, l := range lists {
-		if err := l.removeMedia(media); err != nil {
-			return err
-		}
-	}
+	// Delete associations
+	db.Exec("DELETE FROM list_media WHERE media_id = ?", media.ID)
+	db.Delete(&media)
 
 	// Remove all media files.
 	files := []string{
@@ -179,7 +172,8 @@ func DeleteMedia(id string) error {
 			return err
 		}
 	}
-	return nil
+
+	return db.Error
 }
 
 // DeleteList removes a playlist
@@ -188,6 +182,8 @@ func DeleteList(id string) error {
 	if err != nil {
 		return err
 	}
+	// Delete associations
+	db.Exec("DELETE FROM list_media WHERE list_id = ?", list.ID)
 	db.Delete(&list)
 	return db.Error
 	//return os.Remove(list.file())


### PR DESCRIPTION
Fix #28 

Remove foreign key, as we can't handle mysql and sqlite behavior for the many2many relation
The actual implementation doesn't work at all with sqlite
We have to manage that manually by deleting relations beforedeleting objects